### PR TITLE
Fix default branch detection

### DIFF
--- a/.github/actions/codex/src/git-helpers.ts
+++ b/.github/actions/codex/src/git-helpers.ts
@@ -112,7 +112,7 @@ export async function maybePublishPRForIssue(
 
   const sanitizedMessage = lastMessage.replace(/\u2022/g, "-");
   const [summaryLine] = sanitizedMessage.split(/\r?\n/);
-  const branch = ensureOnBranch(issueNumber, [defaultBranch, "master"], summaryLine);
+  const branch = ensureOnBranch(issueNumber, [defaultBranch], summaryLine);
   commitIfNeeded(issueNumber);
   pushBranch(branch, githubToken, ctx);
 


### PR DESCRIPTION
## Title 
- Codex assumes master branch exists — fails on modern GitHub repos using main

## Summary
- When connecting a GitHub repo to Codex, setup fails with the error:
- Provided git ref master does not exist
- avoid assuming `master` branch in GitHub Action helper

### Expected behavior
Codex should:
	•	Detect the repo’s actual default branch (usually main)
	•	Or allow selecting the desired Git ref during setup
	•	Or provide a more helpful error suggesting that master is missing


## Testing
- `pnpm lint` *(fails: eslint not found)*
- `pnpm test` *(fails: vitest not found)*
- `pnpm typecheck` *(fails: missing dependencies)*
- `pnpm format`
- `npx prettier --check .github/actions/codex/src/git-helpers.ts`


